### PR TITLE
Fix scraper

### DIFF
--- a/scripts/scrape.py
+++ b/scripts/scrape.py
@@ -85,7 +85,9 @@ def extractReposFromPage(soup):
 
 if __name__ == '__main__':
     out = get_list_from_github()
+
+    # Sort and deduplicate.
+    out = sorted(set(out))
     print('Found %s data packages' % len(out))
     out = '\n'.join(out)
     open('catalog-list.txt', 'w').write(out)
-

--- a/scripts/scrape.py
+++ b/scripts/scrape.py
@@ -33,11 +33,16 @@ def get_list_from_github():
     for ii in range(2,pagecount+1):
         turl = url + '&p=%s' % ii
         print('Processing: %s' % turl)
-        fo = urllib.urlopen(turl)
-        if (fo.getcode() >= 400):
-          print('ERROR! Status code: %s, sleeping for 1' % fo.getcode())
-          time.sleep(1)
-          continue
+
+        # Retry until the request succeeds
+        while True:
+            fo = urllib.urlopen(turl)
+            if (fo.getcode() < 400):
+                break
+
+            print('ERROR! Status code: %s, sleeping for 1' % fo.getcode())
+            time.sleep(1)
+
         body = fo.read()
         soup = BeautifulSoup(body)
         try:

--- a/scripts/scrape.py
+++ b/scripts/scrape.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 # We'd so like not to have to scrape this and just use the API but we can't ...
 # http://developer.github.com/changes/2013-10-18-new-code-search-requirements/
 def get_list_from_github():
-    url = 'https://github.com/search?q=name+extension%3Ajson+path%3Adatapackage.json&type=Code&ref=searchresults'
+    url = 'https://github.com/search?l=json&q=name+resources+filename%3Adatapackage.json+path%3A%2F&type=Code'
     fo = urllib.urlopen(url)
     if (fo.getcode() >= 400):
       print('Status code: %s' % fo.getcode())
@@ -15,7 +15,7 @@ def get_list_from_github():
 
     soup = BeautifulSoup(fo.read())
     # total number of results
-    total = int(soup.select('.selected .counter')[0].get_text())
+    total = int(soup.select('.selected .counter')[0].get_text().replace(',', ''))
     print('According to github there are %s data packages' % total)
 
     # do the first one to save loading again


### PR DESCRIPTION
It came up earlier [in #okfn](https://botbot.me/freenode/okfn/2015-04-29/?msg=37903679&page=1) that GitHub's code search appears to have changed. It returns far more results and seems to now match filenames very fuzzily.

I constructed the most restrictive search I could manage and made the scraper somewhat more fault-tolerant. It now verifies that the result for each repo is in fact a datapackage.json file, and will ignore everything else, eventually exiting when five full pages of irrelevant results have been encountered.

It's still far from perfect, and is mostly useful as a coarse discovery tool, not a way to build a definitive list.