### PR TITLE
Add validate script

### DIFF
--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+# vim:sts=4:ts=4:sw=4:expandtab
+
+import argparse
+import json
+import sys
+import urllib
+import webbrowser
+
+def coloured(msg, col):
+    colours = {
+        'green': '\033[00;32m',
+        'red': '\033[00;31m',
+        'reset': '\033[0m'
+    }
+
+    if not col in colours:
+        raise ValueError('Unsupported colour "%s"' % col)
+
+    return colours[col] + msg + colours['reset']
+
+def validate(url):
+    validator = 'http://data.okfn.org/tools/validate'
+    param = urllib.urlencode({ 'url': url })
+    urlo = urllib.urlopen(validator + '.json?' + param)
+
+    data = json.load(urlo)
+
+    if (data['valid'] and args.invalid) or (not data['valid'] and args.valid):
+        return
+
+    if args.quiet:
+        print(url)
+    elif data['valid']:
+        print('[ %s ] ' % coloured('OK', 'green') + url)
+    else:
+        print('[%s] ' % coloured('FAIL', 'red') + url)
+        print('    URL: ' + validator + '?' + param)
+
+        if args.open:
+            webbrowser.open(validator + '?' + param)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-o', '--open', action='store_true',
+        help='open failing validator URLs in a web browser')
+    parser.add_argument('-q', '--quiet', action='store_true',
+        help='with --valid or --invalid, only print the data package\'s URL')
+
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument('--valid', action='store_true',
+        help='only print data packages that pass validation')
+    mode.add_argument('--invalid', action='store_true',
+        help='only print data packages that fail validation')
+    args, rest = parser.parse_known_args()
+
+    if args.quiet and not (args.valid or args.invalid):
+        sys.stderr.write('warning: --quiet has no effect without --valid or'
+            ' --invalid\n')
+        args.quiet = None
+
+    for arg in rest:
+        with open(arg, 'r') as fh:
+            for line in fh:
+                validate(line.rstrip('\n'))


### PR DESCRIPTION
For use in conjunction with the lists in this repo, or any other list
of URLs.

The utility iterates through URLs, passes them to the validator API and
returns whether they passed or failed. For failures, a link to the
validator is provided by default, to see why the failure occurred.

For interest's sake I ran the script against the list @pdehaye posted on #92, and 145 of the 216 successfully validated. I think the updated scraper in conjunction with (semi-)automatic validation would make it much easier to maintain catalog-list.txt.